### PR TITLE
Update test for attr_reader to avoid error msgs

### DIFF
--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "Person" do
         end
 
         it "a new person instance cannot overwrite the name it was instantied with" do
-          name_hash.each do |person, name|
-            expect {person.name = "some_new_name"}.to raise_error
+          people.each do |person|
+            expect(person.respond_to?(:name=)).to be false
           end
         end
       end


### PR DESCRIPTION
Old test returns 

```WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<NoMethodError: undefined method `name=' for #<Person:0x00007fc8cc9ffaa0 @name="Stella">
Did you mean?  name>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/gbennettjones/code/Voxoff/flatiron/mod1/oo-person-teacher-onboarding/spec/person_spec.rb:25:in `block (6 levels) in <top (required)>'. ```